### PR TITLE
added packaging/nix/maybe-initialize-clef

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ package managers and platforms.
 It takes the original `clef` binary and starts it up as a service
 with a special configuration that is probably only suitable for `bee`.
 
-`bee` can be configured to use with other external signers, but
+`bee` can be configured to use other external signers, but
 `bee-clef` is probably not interesting outside the scope of being an
 external signer service for `bee`.
 

--- a/packaging/nix/maybe-initialize-clef
+++ b/packaging/nix/maybe-initialize-clef
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+
+# NOTE This file is not Nix specific in any way, but it's called by
+# the nix package in its preStart hook. It could also be called from
+# the postinst scripts of other packages, but calling scripts is
+# generally unadvised in most packaging guidelines.
+
+DATA_DIR="$1"
+CONFIG_DIR="$2"
+PASSWORD_FILE=${DATA_DIR}/password
+MASTERSEED=${DATA_DIR}/masterseed.json
+KEYSTORE=${DATA_DIR}/keystore
+
+if ! test -f ${PASSWORD_FILE}; then
+    < /dev/urandom tr -dc _A-Z-a-z-0-9 2> /dev/null | head -c32 > ${PASSWORD_FILE}
+    chmod 0600 ${PASSWORD_FILE}
+    chown bee-clef:bee-clef ${PASSWORD_FILE}
+    echo "Initialized ${PASSWORD_FILE} from /dev/urandom"
+fi
+
+if ! test -f ${MASTERSEED}; then
+    parse_json() { echo $1|sed -e 's/[{}]/''/g'|sed -e 's/", "/'\",\"'/g'|sed -e 's/" ,"/'\",\"'/g'|sed -e 's/" , "/'\",\"'/g'|sed -e 's/","/'\"---SEPERATOR---\"'/g'|awk -F=':' -v RS='---SEPERATOR---' "\$1~/\"$2\"/ {print}"|sed -e "s/\"$2\"://"|tr -d "\n\t"|sed -e 's/\\"/"/g'|sed -e 's/\\\\/\\/g'|sed -e 's/^[ \t]*//g'|sed -e 's/^"//' -e 's/"$//' ; }
+    SECRET=$(cat ${PASSWORD_FILE})
+    CLEF="clef --configdir ${DATA_DIR} --keystore ${KEYSTORE} --stdio-ui"
+    $CLEF init >/dev/null << EOF
+$SECRET
+$SECRET
+EOF
+    $CLEF newaccount >/dev/null << EOF
+$SECRET
+EOF
+    $CLEF setpw 0x$(parse_json $(cat ${KEYSTORE}/*) address) >/dev/null << EOF
+$SECRET
+$SECRET
+$SECRET
+EOF
+    $CLEF attest $(sha256sum ${CONFIG_DIR}/rules.js | cut -d' ' -f1 | tr -d '\n') >/dev/null << EOF
+$SECRET
+EOF
+fi


### PR DESCRIPTION
it's basically the same what is in the postinst script, with the following changes:

- removed the stderr redirection
- introduced some shell variables
- it takes the data and cfg dir as args

the current version of the nix package calls this script. the Nix PR is here: https://github.com/NixOS/nixpkgs/pull/109393 (still a draft at the time of writing)