### PR TITLE
fix bee-clef-keys if xclip is missing

### DIFF
--- a/packaging/bee-clef-keys
+++ b/packaging/bee-clef-keys
@@ -7,8 +7,13 @@ _DIR=/var/lib/bee-clef
 _DATE=$(date +%s)
 
 sudo sh -c "install -o ${_USER} -g ${_GROUP} ${_DIR}/keystore/$(sudo ls -1 ${_DIR}/keystore/ | head -1) ${_HOME}/bee-clef-key-${_DATE}.json"
-sudo sh -c "cat ${_DIR}/password | xclip -selection c"
 echo "Key exported to ${_HOME}/bee-clef-key-${_DATE}.json"
-echo "Password loaded into clipboard and ready to be pasted"
+if command -v xclip >/dev/null 2>&1; then
+    sudo sh -c "cat ${_DIR}/password | xclip -selection c"
+    echo "Password loaded into clipboard and ready to be pasted"
+else
+    sudo sh -c "install -o ${_USER} -g ${_GROUP} ${_DIR}/password ${_HOME}/bee-clef-password-${_DATE}.txt"
+    echo "Pass exported to ${_HOME}/bee-clef-password-${_DATE}.txt"
+fi
 
 exit 0


### PR DESCRIPTION
If xclip is missing from the machine password will be also exported to $HOME folder and info will be printed to the user