### PR TITLE
add --lightkdf arg for clef's newaccount command

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -8,7 +8,7 @@ if [ "$1" = "configure" ]; then
 $SECRET
 $SECRET
 EOF
-        clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount >/dev/null 2>&1 << EOF
+        clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
 $SECRET
 EOF
         clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x$(parse_json $(cat /var/lib/bee-clef/keystore/*) address) >/dev/null 2>&1 << EOF

--- a/packaging/docker/entrypoint.sh
+++ b/packaging/docker/entrypoint.sh
@@ -15,7 +15,7 @@ $SECRET
 $SECRET
 EOF
     if [ "$(ls -A "$DATA"/keystore 2> /dev/null)" = "" ]; then
-        /usr/local/bin/clef --keystore "$DATA"/keystore --stdio-ui newaccount >/dev/null 2>&1 << EOF
+        /usr/local/bin/clef --keystore "$DATA"/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
 $SECRET
 EOF
     fi

--- a/packaging/homebrew/swarm-clef-init
+++ b/packaging/homebrew/swarm-clef-init
@@ -7,7 +7,7 @@ if [ "$(ls -A /usr/local/var/lib/swarm-clef/keystore 2> /dev/null)" = "" ]; then
 $SECRET
 $SECRET
 EOF
-    /usr/local/bin/clef --keystore /usr/local/var/lib/swarm-clef/keystore --stdio-ui newaccount >/dev/null 2>&1 << EOF
+    /usr/local/bin/clef --keystore /usr/local/var/lib/swarm-clef/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
 $SECRET
 EOF
     /usr/local/bin/clef --keystore /usr/local/var/lib/swarm-clef/keystore --configdir /usr/local/var/lib/swarm-clef --stdio-ui setpw 0x$(parse_json $(cat /usr/local/var/lib/swarm-clef/keystore/*) address) >/dev/null 2>&1 << EOF

--- a/packaging/rpm/post
+++ b/packaging/rpm/post
@@ -6,7 +6,7 @@ if [ $1 -eq 1 ] ; then
 $SECRET
 $SECRET
 EOF
-    clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount >/dev/null 2>&1 << EOF
+    clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
 $SECRET
 EOF
     clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x$(parse_json $(cat /var/lib/bee-clef/keystore/*) address) >/dev/null 2>&1 << EOF


### PR DESCRIPTION
clef's memory usage can be enormous with the normal KDF parameters,
sometimes growing beyond 10GB! with this change, it remains in
the ballpark of 70kB.

https://github.com/ethereum/go-ethereum/issues/22361