### PR TITLE
initial support for multi keys

### DIFF
--- a/packaging/bee-clef-service
+++ b/packaging/bee-clef-service
@@ -14,7 +14,7 @@ start() {
     echo "bee-clef-service ${DATA_DIR} ${PASSWORD_FILE} ${CONFIG_DIR}"
 
     KEYSTORE=${DATA_DIR}/keystore
-    SECRET=$(cat ${PASSWORD_FILE})
+    MASTER_SECRET=$(cat ${PASSWORD_FILE})
     CHAINID=${BEE_CLEF_CHAIN_ID:-5}
     # clef with every start sets permissions back to 600
     rm --force ${DATA_DIR}/clef.ipc || true
@@ -29,7 +29,7 @@ start() {
     while read < ${DATA_DIR}/stdout
     do
         if [[ "$REPLY" =~ "enter the password" ]]; then
-            echo '{ "jsonrpc": "2.0", "id":1, "result": { "text":"'"$SECRET"'" } }' > ${DATA_DIR}/stdin
+            echo '{ "jsonrpc": "2.0", "id":1, "result": { "text":"'"$MASTER_SECRET"'" } }' > ${DATA_DIR}/stdin
             break
         fi
     done

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -2,24 +2,43 @@
 
 if [ "$1" = "configure" ]; then
     if [ -z "$2" ]; then
-        SECRET=$(cat /var/lib/bee-clef/password)
-        parse_json() { echo $1|sed -e 's/[{}]/''/g'|sed -e 's/", "/'\",\"'/g'|sed -e 's/" ,"/'\",\"'/g'|sed -e 's/" , "/'\",\"'/g'|sed -e 's/","/'\"---SEPERATOR---\"'/g'|awk -F=':' -v RS='---SEPERATOR---' "\$1~/\"$2\"/ {print}"|sed -e "s/\"$2\"://"|tr -d "\n\t"|sed -e 's/\\"/"/g'|sed -e 's/\\\\/\\/g'|sed -e 's/^[ \t]*//g'|sed -e 's/^"//' -e 's/"$//' ; }
+        TOTAL_ACCOUNTS=${BEE_CLEF_TOTAL_ACCOUNTS:-1}
+        MASTER_SECRET=$(cat /var/lib/bee-clef/password)
         clef --configdir /var/lib/bee-clef --stdio-ui init >/dev/null 2>&1 << EOF
-$SECRET
+$MASTER_SECRET
+$MASTER_SECRET
+EOF
+        number=0
+        while [ $number -lt "${TOTAL_ACCOUNTS}" ] 
+        do
+            SECRET=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 2> /dev/null | head -c32)
+            ACCOUNT=$({
+            clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf 2>/dev/null << EOF
 $SECRET
 EOF
-        clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
+} | tail -n -1 | cut -d'x' -f2 | tr '[:upper:]' '[:lower:]')
+            clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x"${ACCOUNT}" >/dev/null 2>&1 << EOF
 $SECRET
+$SECRET
+$MASTER_SECRET
 EOF
-        clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x$(parse_json $(cat /var/lib/bee-clef/keystore/*) address) >/dev/null 2>&1 << EOF
-$SECRET
-$SECRET
-$SECRET
-EOF
+            if [ $number -lt 10 ] && [ $TOTAL_ACCOUNTS -gt 9 ]; then
+                FILENAME=bee-0"${number}"_"${ACCOUNT}"
+            else
+                FILENAME=bee-"${number}"_"${ACCOUNT}"
+            fi
+            printf '%s' "${SECRET}" > /var/lib/bee-clef/passwords/"${FILENAME}"
+            chmod 0600 /var/lib/bee-clef/passwords/"${FILENAME}"
+            chown bee-clef:bee-clef /var/lib/bee-clef/passwords/"${FILENAME}"
+            number=$((number+1))
+        done
         clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui attest $(sha256sum /etc/bee-clef/rules.js | cut -d' ' -f1 | tr -d '\n') >/dev/null 2>&1 << EOF
-$SECRET
+$MASTER_SECRET
 EOF
         chown -R bee-clef:bee-clef /var/lib/bee-clef
+        echo "Accounts initilized, configure bee with coresponding address value"
+        ls -1 /var/lib/bee-clef/passwords
+        echo
     fi
     deb-systemd-helper unmask bee-clef.service >/dev/null || true
 

--- a/packaging/deb/preinst
+++ b/packaging/deb/preinst
@@ -9,8 +9,10 @@ if [ "$1" = "install" ]; then
     fi
     if ! test -d /var/lib/bee-clef; then
         mkdir -p /var/lib/bee-clef/keystore
+        mkdir -p /var/lib/bee-clef/passwords
         chmod 0750 /var/lib/bee-clef
         chmod 0700 /var/lib/bee-clef/keystore
+        chmod 0700 /var/lib/bee-clef/passwords
         chown -R bee-clef:bee-clef /var/lib/bee-clef
     fi
     if ! test -f /var/lib/bee-clef/password; then

--- a/packaging/rpm/post
+++ b/packaging/rpm/post
@@ -1,24 +1,42 @@
 if [ $1 -eq 1 ] ; then
     # Initial installation
-    SECRET=$(cat /var/lib/bee-clef/password)
-    parse_json() { echo $1|sed -e 's/[{}]/''/g'|sed -e 's/", "/'\",\"'/g'|sed -e 's/" ,"/'\",\"'/g'|sed -e 's/" , "/'\",\"'/g'|sed -e 's/","/'\"---SEPERATOR---\"'/g'|awk -F=':' -v RS='---SEPERATOR---' "\$1~/\"$2\"/ {print}"|sed -e "s/\"$2\"://"|tr -d "\n\t"|sed -e 's/\\"/"/g'|sed -e 's/\\\\/\\/g'|sed -e 's/^[ \t]*//g'|sed -e 's/^"//' -e 's/"$//' ; }
+    TOTAL_ACCOUNTS=${BEE_CLEF_TOTAL_ACCOUNTS:-1}
+    MASTER_SECRET=$(cat /var/lib/bee-clef/password)
     clef --configdir /var/lib/bee-clef --stdio-ui init >/dev/null 2>&1 << EOF
-$SECRET
+$MASTER_SECRET
+$MASTER_SECRET
+EOF
+    number=0
+    while [ $number -lt "${TOTAL_ACCOUNTS}" ] 
+    do
+        SECRET=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 2> /dev/null | head -c32)
+        ACCOUNT=$({
+        clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf 2>/dev/null << EOF
 $SECRET
 EOF
-    clef --keystore /var/lib/bee-clef/keystore --stdio-ui newaccount --lightkdf >/dev/null 2>&1 << EOF
+} | tail -n -1 | cut -d'x' -f2 | tr '[:upper:]' '[:lower:]')
+        clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x"${ACCOUNT}" >/dev/null 2>&1 << EOF
 $SECRET
+$SECRET
+$MASTER_SECRET
 EOF
-    clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui setpw 0x$(parse_json $(cat /var/lib/bee-clef/keystore/*) address) >/dev/null 2>&1 << EOF
-$SECRET
-$SECRET
-$SECRET
-EOF
+        if [ $number -lt 10 ] && [ $TOTAL_ACCOUNTS -gt 9 ]; then
+            FILENAME=bee-0"${number}"_"${ACCOUNT}"
+        else
+            FILENAME=bee-"${number}"_"${ACCOUNT}"
+        fi
+        printf '%s' "${SECRET}" > /var/lib/bee-clef/passwords/"${FILENAME}"
+        chmod 0600 /var/lib/bee-clef/passwords/"${FILENAME}"
+        chown bee-clef:bee-clef /var/lib/bee-clef/passwords/"${FILENAME}"
+        number=$((number+1))
+    done
     clef --keystore /var/lib/bee-clef/keystore --configdir /var/lib/bee-clef --stdio-ui attest $(sha256sum /etc/bee-clef/rules.js | cut -d' ' -f1 | tr -d '\n') >/dev/null 2>&1 << EOF
-$SECRET
+$MASTER_SECRET
 EOF
     chown -R bee-clef:bee-clef /var/lib/bee-clef
-
+    echo "Accounts initilized, configure bee with coresponding address value"
+    ls -1 /var/lib/bee-clef/passwords
+    echo
     systemctl --no-reload preset bee-clef.service &>/dev/null || :
     systemctl --no-reload enable bee-clef.service &>/dev/null || :
     systemctl --no-reload start bee-clef.service &>/dev/null || :

--- a/packaging/rpm/pre
+++ b/packaging/rpm/pre
@@ -8,8 +8,10 @@ if [ $1 -eq 1 ] ; then
     fi
     if ! test -d /var/lib/bee-clef; then
         mkdir -p /var/lib/bee-clef/keystore
+        mkdir -p /var/lib/bee-clef/passwords
         chmod 0750 /var/lib/bee-clef
         chmod 0700 /var/lib/bee-clef/keystore
+        chmod 0700 /var/lib/bee-clef/passwords
         chown -R bee-clef:bee-clef /var/lib/bee-clef
     fi
     if ! test -f /var/lib/bee-clef/password; then


### PR DESCRIPTION
If user needs clef serving multiple accounts during installation it should set `BEE_CLEF_TOTAL_ACCOUNTS`
```
export BEE_CLEF_TOTAL_ACCOUNTS=5
sudo -E dpkg -i bee-clef_0.7.0_amd64.deb
```